### PR TITLE
git-controller not valid json in log function

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -22,7 +22,7 @@ parsers.log = function(output) {
     if (h) {
         for (var i = h.length - 1; i >= 0; i--) {
             var hh = h[i].replace(jsonValueRegex, '$1');
-            var hhh = hh.replace(/\"/g, '\\"').replace(/\'/g, "");
+            var hhh = hh.replace(/\"/g, '\\"').replace(/\'/g, "").replace( /\^</g, '<').replace( /\^>/g, '>');
 
             log = log.replace(hh, hhh);
         }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -22,7 +22,7 @@ parsers.log = function(output) {
     if (h) {
         for (var i = h.length - 1; i >= 0; i--) {
             var hh = h[i].replace(jsonValueRegex, '$1');
-            var hhh = hh.replace(/\"/g, '\\"').replace(/\'/g, "").replace( /\^</g, '<').replace( /\^>/g, '>');
+            var hhh = hh.replace(/\"/g, '\\"').replace(/\'/g, "");
 
             log = log.replace(hh, hhh);
         }

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -2,6 +2,7 @@
  * @module gitty/repository
  */
 
+var os = require('os');
 var fs = require('fs');
 var path = require('path');
 var util = require('util');
@@ -10,6 +11,9 @@ var parse = require('./parser');
 var events = require('events');
 var logFmt = '--pretty=format:\'{"commit":"%H","author":"%an <%ae>",' +
     '"date":"%ad","message":"%s"},\'';
+var logFmtWin32 = '--pretty=format:{\\"commit\\":\\"%H\\",\\"author\\":"\\"%an ^<%ae^>\\"",' +
+    '\\"date\\":\\"%ad\\",\\"message\\":\\"%s\\"},';
+
 
 /**
  * Constructor function for all repository commands
@@ -86,7 +90,7 @@ Repository.prototype.log = function() {
     var args = Array.prototype.slice.apply(arguments);
     var path = typeof args[0] === 'string' ? args[0] : '';
     var done = args.slice(-1).pop() || function() {};
-    var cmd = new Command(self.path, 'log', [logFmt, path]);
+    var cmd = new Command(self.path, 'log', [os.platform() == 'win32' ? logFmtWin32 : logFmt, path]);
 
     cmd.exec(function(err, stdout, stderr) {
         if (err || stderr) {
@@ -104,7 +108,7 @@ Repository.prototype.log = function() {
  */
 Repository.prototype.logSync = function(branch) {
     var self = this;
-    var cmd = new Command(self.path, 'log', [logFmt, branch || '']);
+    var cmd = new Command(self.path, 'log', [os.platform() == 'win32' ? logFmtWin32 : logFmt, branch || '']);
 
     return parse.log(cmd.execSync());
 };

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -8,8 +8,8 @@ var util = require('util');
 var Command = require('./command');
 var parse = require('./parser');
 var events = require('events');
-var logFmt = '--pretty=format:\'{"commit":"%H","author":"%an <%ae>",' +
-    '"date":"%ad","message":"%s"},\'';
+var logFmt = '--pretty=format:\'{\"commit\":\"%H\",\"author\":\"%an ^<%ae^>\",' +
+    '\"date\":\"%ad\",\"message\":\"%s\"},\'';
 
 /**
  * Constructor function for all repository commands

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -8,8 +8,8 @@ var util = require('util');
 var Command = require('./command');
 var parse = require('./parser');
 var events = require('events');
-var logFmt = '--pretty=format:\'{\"commit\":\"%H\",\"author\":\"%an ^<%ae^>\",' +
-    '\"date\":\"%ad\",\"message\":\"%s\"},\'';
+var logFmt = '--pretty=format:\'{"commit":"%H","author":"%an <%ae>",' +
+    '"date":"%ad","message":"%s"},\'';
 
 /**
  * Constructor function for all repository commands


### PR DESCRIPTION
I've made this little modification because git-controller wasn't working well under windows architecture. 

The command git log with the "pretty format" specification `'--pretty=format:\'{"commit":"%H","author":"%an <%ae>","date":"%ad","message":"%s"},\''` was returning a valid JSON under linux but returned **an invalid json (a JSON without double quotes symbols) under windows**.

I tried different solutions such as a "pretty format" string valid for both architecture but they required post-processing of the string in the "subscribing" methods.

So, I thought this solution, with two string depending on the os, could be the safest and cleanest.

What do you think?
It's strange that nobody has ever happened to run into this problem before, so I'm left with the doubt.
David